### PR TITLE
🛠️ Create pull request body generation with template and diff

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Motiviation
+
+<!-- Describe the motivation behind this PR -->
+
+# Changes
+
+<!-- Describe the changes made in this PR -->
+
+# Expected behavior
+
+<!-- Describe the expected behavior of the changes made in this PR -->

--- a/main.go
+++ b/main.go
@@ -44,7 +44,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if generatedBody := utils.GenerateBody(commits, diff); generatedBody != nil {
+	template, err := utils.GetPRTemplate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting PR template: %v\n", err)
+		os.Exit(1)
+	}
+
+	if generatedBody := utils.GenerateBody(commits, diff, template); generatedBody != nil {
 		args = append(args, "--body", *generatedBody)
 	}
 

--- a/main.go
+++ b/main.go
@@ -23,8 +23,13 @@ func main() {
 	}
 
 	extraArgs := os.Args[1:]
+	args := []string{"pr", "create", "--title", fullTitle}
 
-	args := append([]string{"pr", "create", "--title", fullTitle}, extraArgs...)
+	if generatedBody := utils.GenerateBody(commits); generatedBody != nil {
+		args = append(args, "--body", *generatedBody)
+	}
+
+	args = append(args, extraArgs...)
 
 	cmd := exec.Command("gh", args...)
 	cmd.Stdout = os.Stdout

--- a/main.go
+++ b/main.go
@@ -38,7 +38,13 @@ func main() {
 	extraArgs := os.Args[1:]
 	args := []string{"pr", "create", "--title", fullTitle}
 
-	if generatedBody := utils.GenerateBody(commits); generatedBody != nil {
+	diff, err := utils.GetDiff(baseBranch)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting diff: %v\n", err)
+		os.Exit(1)
+	}
+
+	if generatedBody := utils.GenerateBody(commits, diff); generatedBody != nil {
 		args = append(args, "--body", *generatedBody)
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,17 +9,30 @@ import (
 )
 
 func main() {
-	baseBranch := utils.DetectBaseBranch()
-	commits := utils.GetCommitsHistory(baseBranch)
+	baseBranch, err := utils.DetectBaseBranch()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error detecting base branch: %v\n", err)
+		os.Exit(1)
+	}
+	
+	commits, err := utils.GetCommitsHistory(baseBranch)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting commit history: %v\n", err)
+		os.Exit(1)
+	}
 
 	var fullTitle string
 
 	if generatedTitle := utils.GenerateTitle(commits); generatedTitle != nil {
 		fullTitle = *generatedTitle
 	} else {
-		defaulTitle := utils.GetDefaultTitle(baseBranch)
+		defaultTitle, err := utils.GetDefaultTitle(baseBranch)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting default title: %v\n", err)
+			os.Exit(1)
+		}
 
-		fullTitle = fmt.Sprintf("%s %s", utils.GetRandomEmoji(), defaulTitle)
+		fullTitle = fmt.Sprintf("%s %s", utils.GetRandomEmoji(), defaultTitle)
 	}
 
 	extraArgs := os.Args[1:]
@@ -36,5 +49,8 @@ func main() {
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 
-	cmd.Run()
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating pull request: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/mise.toml
+++ b/mise.toml
@@ -3,3 +3,5 @@ go = "latest"
 
 [tasks]
 build = "go build -o gh-epr"
+local = "go build -o gh-epr && (gh extension remove gh-epr || true) && gh extension install . && printf \"\\033[32m✓\\033[0m Installed local extension\n\""
+prod = "go build -o gh-epr && (gh extension remove gh-epr || true) && gh extension install wannabehero/gh-epr"

--- a/utils/git.go
+++ b/utils/git.go
@@ -6,40 +6,93 @@ import (
 	"strings"
 )
 
-func runCmd(name string, args ...string) string {
+func runCmd(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	output, err := cmd.Output()
 	if err != nil {
-		return fmt.Sprintf("Error running command: %v", err)
+		return "", fmt.Errorf("error running command '%s %s': %w", name, strings.Join(args, " "), err)
 	}
-	return strings.TrimSpace(string(output))
+	return strings.TrimSpace(string(output)), nil
 }
 
-func GetCommitsHistory(baseBranch string) []string {
-	commits := runCmd("git", "log", "--pretty=format:%s", fmt.Sprintf("origin/%s..HEAD", baseBranch))
-	messages := strings.Split(commits, "\n")
-	return messages
+func GetCommitsHistory(baseBranch string) ([]string, error) {
+	remotes, err := runCmd("git", "remote")
+	if err != nil {
+		return nil, err
+	}
+	
+	remotesList := strings.Split(remotes, "\n")
+	
+	remoteRefs, err := runCmd("git", "branch", "-r")
+	if err != nil {
+		return nil, err
+	}
+	
+	for _, remote := range remotesList {
+		if remote == "" {
+			continue
+		}
+		
+		remoteRef := fmt.Sprintf("%s/%s", remote, baseBranch)
+		
+		if !strings.Contains(remoteRefs, remoteRef) {
+			continue
+		}
+		
+		commits, err := runCmd("git", "log", "--pretty=format:%s", fmt.Sprintf("%s..HEAD", remoteRef))
+		if err == nil && commits != "" {
+			return strings.Split(commits, "\n"), nil
+		}
+	}
+	
+	return []string{}, nil
 }
 
-func GetDefaultTitle(baseBranch string) string {
-	messages := GetCommitsHistory(baseBranch)
+func GetDefaultTitle(baseBranch string) (string, error) {
+	messages, err := GetCommitsHistory(baseBranch)
+	if err != nil {
+		return "", err
+	}
+	
 	if len(messages) == 1 && messages[0] != "" {
-		return messages[0]
+		return messages[0], nil
 	}
 
-	branchName := runCmd("git", "rev-parse", "--abbrev-ref", "HEAD")
-	return branchName
+	branchName, err := runCmd("git", "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	
+	return branchName, nil
 }
 
-func DetectBaseBranch() string {
-	branches := runCmd("git", "branch", "-r")
-	if strings.Contains(branches, "origin/main") {
-		return "main"
+func DetectBaseBranch() (string, error) {
+	branches, err := runCmd("git", "branch", "-r")
+	if err != nil {
+		return "", err
 	}
-	if strings.Contains(branches, "origin/master") {
-		return "master"
+	
+	baseBranchNames := []string{"main", "master", "dev", "develop", "trunk"}
+	
+	remotes, err := runCmd("git", "remote")
+	if err != nil {
+		return "", err
+	}
+	
+	remotesList := strings.Split(remotes, "\n")
+	
+	for _, baseName := range baseBranchNames {
+		for _, remote := range remotesList {
+			if remote == "" {
+				continue
+			}
+			
+			remoteRef := fmt.Sprintf("%s/%s", remote, baseName)
+			if strings.Contains(branches, remoteRef) {
+				return baseName, nil
+			}
+		}
 	}
 
-	// Default to main branch if no other branch is found
-	return "main"
+	return "main", nil
 }

--- a/utils/git.go
+++ b/utils/git.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -118,4 +120,32 @@ func GetDiff(baseBranch string) (string, error) {
 	}
 	
 	return diff, nil
+}
+
+func GetPRTemplate() (string, error) {
+	repoRoot, err := runCmd("git", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+
+	githubDir := filepath.Join(repoRoot, ".github")
+	if _, err := os.Stat(githubDir); os.IsNotExist(err) {
+		return "", nil
+	}
+
+	dirEntries, err := os.ReadDir(githubDir)
+	if err != nil {
+		return "", nil
+	}
+
+	for _, entry := range dirEntries {
+		if !entry.IsDir() && strings.EqualFold(entry.Name(), "pull_request_template.md") {
+			content, err := os.ReadFile(filepath.Join(githubDir, entry.Name()))
+			if err == nil {
+				return string(content), nil
+			}
+		}
+	}
+
+	return "", nil
 }

--- a/utils/llm.go
+++ b/utils/llm.go
@@ -30,7 +30,7 @@ Commit messages:
 `
 
 const BODY_PROMPT = `
-Using the following commit messages as a context
+Using the following commit messages and diff as context,
 generate a descriptive Pull Request body that summarizes the changes.
 Include a brief summary section with 1-3 bullet points describing the key changes.
 Be concise and to the point.
@@ -38,6 +38,9 @@ Be concise and to the point.
 Format it in Markdown with proper headings.
 
 Commit messages:
+%s
+
+Diff:
 %s
 `
 
@@ -84,7 +87,7 @@ func GenerateTitle(commits []string) *string {
 	return &response.Title
 }
 
-func GenerateBody(commits []string) *string {
+func GenerateBody(commits []string, diff string) *string {
 	generator := getAvailableGenerator()
 
 	if generator == nil {
@@ -93,7 +96,7 @@ func GenerateBody(commits []string) *string {
 
 	res, err := generator.
 		Output(schema.From(BodyResponse{})).
-		Prompt(prompt.AsUser(fmt.Sprintf(BODY_PROMPT, strings.Join(commits, "\n"))))
+		Prompt(prompt.AsUser(fmt.Sprintf(BODY_PROMPT, strings.Join(commits, "\n"), diff)))
 
 	if err != nil {
 		return nil

--- a/utils/llm.go
+++ b/utils/llm.go
@@ -32,9 +32,8 @@ Commit messages:
 const BODY_PROMPT = `
 Using the following commit messages as a context
 generate a descriptive Pull Request body that summarizes the changes.
-Include:
-1. A brief summary section with 1-3 bullet points describing the key changes
-2. A test plan section that outlines how these changes should be tested
+Include a brief summary section with 1-3 bullet points describing the key changes.
+Be concise and to the point.
 
 Format it in Markdown with proper headings.
 


### PR DESCRIPTION
# Motivation

To improve the Pull Request creation process in the gh-epr tool by adding structured body generation capabilities and error handling. The tool now uses PR templates when available and includes diff information for more comprehensive PR descriptions.

# Changes

- Added PR template support with a new `.github/pull_request_template.md` file
- Enhanced error handling throughout the codebase, particularly in git operations
- Implemented diff-based body generation using commit messages and code changes
- Added new utility functions for template and diff processing
- Introduced local/prod tasks in mise.toml for easier development and deployment
- Improved git operations with better remote reference handling

# Expected behavior

- The tool will now detect and use PR templates if they exist in the repository
- When creating a PR, a structured body will be generated based on:
  - Commit messages
  - Code diff
  - Repository's PR template (if available)
- More robust error handling will provide clear feedback when operations fail
- Developers can easily switch between local and production versions using new mise tasks